### PR TITLE
chore: skip 4xx client errors in Sentry reporting

### DIFF
--- a/services/sentry.service.ts
+++ b/services/sentry.service.ts
@@ -1,7 +1,7 @@
 // @ts-ignore
 import SentryMixin from 'moleculer-sentry';
-import moleculer from 'moleculer';
-import { Service } from 'moleculer-decorators';
+import moleculer, { Errors } from 'moleculer';
+import { Method, Service } from 'moleculer-decorators';
 import { Integrations } from '@sentry/node';
 
 @Service({
@@ -30,4 +30,14 @@ import { Integrations } from '@sentry/node';
     },
   },
 })
-export default class SentryService extends moleculer.Service {}
+export default class SentryService extends moleculer.Service {
+  @Method
+  shouldReport({ error }: { error: Errors.MoleculerError }): boolean {
+    // Skip 4xx client errors — normal traffic, not server bugs
+    if ([401, 404].includes(error?.code)) {
+      return false;
+    }
+
+    return true;
+  }
+}


### PR DESCRIPTION
## Problem

`moleculer-sentry` reports every traced error to Sentry by default — including **4xx client errors** like `401 Unauthorized` and `404 Not Found`. These are not server bugs: they happen every time a token expires, a mobile client requests a deleted resource, or a bot scanner probes a random URL. In production they drown real issues in noise.

This repo's `sentry.service.ts` was missing the `shouldReport` method. 6 other BĮIP APIs already had the same filter (`biip-auth-api`, `biip-gyvunai-api`, `biip-hidro-api`, `biip-rusys-api`, `biip-uetk-api`, `biip-zvejyba-api`) — this change brings this repo in line with that pattern.

## Fix

Added `shouldReport` method that returns `false` for `401` and `404`. `moleculer-sentry` calls it on every error event (see [`moleculer-sentry/src/index.js:150`](https://github.com/LuxChanLu/moleculer-sentry/blob/master/src/index.js)) — anything other than `true` causes the error to be skipped.

## Test plan

- [ ] After deploy, confirm `401`/`404` events stop appearing in Sentry for this service
- [ ] Server-side (`5xx`) errors continue to be reported normally
- [ ] No change in application behaviour, only Sentry noise reduction
