### PR TITLE
Add /gdb endpoint: GeoJSON → ESRI File Geodatabase (zipped)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 # Stage 1: Base image
 FROM node:20-alpine as base
 
-# Required for dependencies coming from git
-RUN apk add --no-cache git
+# Required for dependencies coming from git, plus gdal-tools (ogr2ogr) for
+# the /gdb endpoint that converts GeoJSON to ESRI File Geodatabase, and zip
+# to package the .gdb directory tree as a single archive.
+RUN apk add --no-cache git gdal-tools zip
 
 # Stage 2: Builder image
 FROM base as builder

--- a/services/api.service.ts
+++ b/services/api.service.ts
@@ -90,13 +90,16 @@ import ApiGateway from 'moleculer-web';
         callingOptions: {},
 
         bodyParsers: {
+          // 25MB accommodates GeoJSON payloads for the /gdb endpoint, which
+          // can be several MB for requests with many objects. Other endpoints
+          // (/pdf, /download, /screenshot) take URL params and are unaffected.
           json: {
             strict: false,
-            limit: '1MB',
+            limit: '25MB',
           },
           urlencoded: {
             extended: true,
-            limit: '1MB',
+            limit: '25MB',
           },
         },
 

--- a/services/gdb.service.ts
+++ b/services/gdb.service.ts
@@ -43,9 +43,12 @@ export default class GdbService extends moleculer.Service {
         type: 'string',
         optional: true,
         default: 'extract',
-        pattern: '^[A-Za-z0-9._-]+$',
+        // Defense in depth: even with shell:false + absolute paths, disallow
+        // leading - or . to avoid edge-case argv parsing (--foo, ..) and bare
+        // dotfiles. Also cap length.
+        pattern: '^[A-Za-z0-9_][A-Za-z0-9._-]{0,63}$',
         $$t:
-          'Base name for the .gdb directory inside the ZIP (must be a safe filename — letters, digits, dot, dash, underscore)',
+          'Base name for the .gdb directory inside the ZIP (alnum start; up to 64 chars of letters, digits, dot, dash, underscore)',
       },
     },
     rest: ['POST /'],
@@ -133,12 +136,13 @@ export default class GdbService extends moleculer.Service {
         stdio: ['ignore', 'pipe', 'pipe'],
         shell: false,
       });
-      const stderrChunks: Buffer[] = [];
-      child.stderr.on('data', (chunk) => stderrChunks.push(chunk));
+      const stderrChunks: string[] = [];
+      child.stderr.setEncoding('utf8');
+      child.stderr.on('data', (chunk: string) => stderrChunks.push(chunk));
       child.on('error', reject);
       child.on('close', (code) => {
         if (code === 0) return resolve();
-        const stderr = Buffer.concat(stderrChunks).toString('utf8');
+        const stderr = stderrChunks.join('');
         reject(
           new Errors.MoleculerError(
             `ogr2ogr exited with code ${code}: ${stderr || '<no stderr>'}`,
@@ -158,12 +162,13 @@ export default class GdbService extends moleculer.Service {
         stdio: ['ignore', 'pipe', 'pipe'],
         shell: false,
       });
-      const stderrChunks: Buffer[] = [];
-      child.stderr.on('data', (chunk) => stderrChunks.push(chunk));
+      const stderrChunks: string[] = [];
+      child.stderr.setEncoding('utf8');
+      child.stderr.on('data', (chunk: string) => stderrChunks.push(chunk));
       child.on('error', reject);
       child.on('close', (code) => {
         if (code === 0) return resolve();
-        const stderr = Buffer.concat(stderrChunks).toString('utf8');
+        const stderr = stderrChunks.join('');
         reject(
           new Errors.MoleculerError(
             `zip exited with code ${code}: ${stderr || '<no stderr>'}`,

--- a/services/gdb.service.ts
+++ b/services/gdb.service.ts
@@ -1,0 +1,177 @@
+'use strict';
+
+import { spawn } from 'child_process';
+import { promises as fsp, createReadStream } from 'fs';
+import moleculer, { Context, Errors } from 'moleculer';
+import { Action, Method, Service } from 'moleculer-decorators';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+@Service({
+  name: 'gdb',
+})
+export default class GdbService extends moleculer.Service {
+  @Action({
+    openapi: {
+      summary:
+        'Converts a GeoJSON FeatureCollection to an ESRI File Geodatabase (OpenFileGDB) packed as a ZIP archive.',
+      responses: {
+        '200': {
+          description: 'ZIP archive containing the .gdb directory.',
+          content: {
+            'application/zip': {
+              schema: { type: 'string', format: 'binary' },
+            },
+          },
+        },
+      },
+    },
+    params: {
+      geojson: {
+        type: 'object',
+        $$t: 'GeoJSON FeatureCollection to convert',
+      },
+      srid: {
+        type: 'number',
+        convert: true,
+        optional: true,
+        default: 3346,
+        $$t:
+          'Source / target SRID. Defaults to 3346 (LKS-94 — Lithuanian national grid)',
+      },
+      name: {
+        type: 'string',
+        optional: true,
+        default: 'extract',
+        pattern: '^[A-Za-z0-9._-]+$',
+        $$t:
+          'Base name for the .gdb directory inside the ZIP (must be a safe filename — letters, digits, dot, dash, underscore)',
+      },
+    },
+    rest: ['POST /'],
+    timeout: 0,
+  })
+  async create(
+    ctx: Context<
+      { geojson: any; srid: number; name: string },
+      {
+        $responseType: string;
+        $statusCode: number;
+        $responseHeaders: any;
+      }
+    >,
+  ) {
+    const { geojson, srid, name } = ctx.params;
+
+    if (!geojson?.type || geojson.type !== 'FeatureCollection') {
+      throw new Errors.MoleculerClientError(
+        'geojson must be a FeatureCollection',
+        400,
+        'INVALID_GEOJSON',
+      );
+    }
+    if (!Array.isArray(geojson.features) || geojson.features.length === 0) {
+      throw new Errors.MoleculerClientError(
+        'geojson.features must be a non-empty array',
+        400,
+        'EMPTY_FEATURES',
+      );
+    }
+
+    const workDir = await fsp.mkdtemp(join(tmpdir(), `gdb-`));
+    const geojsonPath = join(workDir, `${name}.geojson`);
+    const gdbDir = join(workDir, `${name}.gdb`);
+    const zipPath = join(workDir, `${name}.zip`);
+
+    try {
+      await fsp.writeFile(geojsonPath, JSON.stringify(geojson));
+
+      // ogr2ogr: GeoJSON -> OpenFileGDB. -a_srs assigns the input's spatial
+      // reference (GeoJSON spec defines CRS84 but biip uses 3346 throughout).
+      // Binary path is literal; inputs are paths inside our private workDir.
+      await this.runOgr2Ogr([
+        '-f',
+        'OpenFileGDB',
+        '-a_srs',
+        `EPSG:${srid}`,
+        gdbDir,
+        geojsonPath,
+      ]);
+
+      // Pack the .gdb directory at workDir root so the archive entry is
+      // "<name>.gdb/..." (the conventional layout ArcGIS / QGIS expect).
+      await this.runZip(['-rq', zipPath, `${name}.gdb`], workDir);
+
+      const stat = await fsp.stat(zipPath);
+
+      ctx.meta.$responseType = 'application/zip';
+      ctx.meta.$statusCode = 200;
+      ctx.meta.$responseHeaders = {
+        'Content-Disposition': `attachment; filename="${name}.zip"`,
+        'Content-Length': stat.size.toString(),
+      };
+
+      const stream = createReadStream(zipPath);
+      // Stream ends -> safe to remove the workDir. Errors on the stream
+      // bubble up via the response; cleanup still happens.
+      const cleanup = () =>
+        fsp.rm(workDir, { recursive: true, force: true }).catch(() => {});
+      stream.on('close', cleanup);
+      stream.on('error', cleanup);
+
+      return stream;
+    } catch (e) {
+      await fsp.rm(workDir, { recursive: true, force: true }).catch(() => {});
+      throw e;
+    }
+  }
+
+  @Method
+  runOgr2Ogr(args: string[]) {
+    return new Promise<void>((resolve, reject) => {
+      const child = spawn('ogr2ogr', args, {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        shell: false,
+      });
+      const stderrChunks: Buffer[] = [];
+      child.stderr.on('data', (chunk) => stderrChunks.push(chunk));
+      child.on('error', reject);
+      child.on('close', (code) => {
+        if (code === 0) return resolve();
+        const stderr = Buffer.concat(stderrChunks).toString('utf8');
+        reject(
+          new Errors.MoleculerError(
+            `ogr2ogr exited with code ${code}: ${stderr || '<no stderr>'}`,
+            500,
+            'OGR2OGR_FAILED',
+          ),
+        );
+      });
+    });
+  }
+
+  @Method
+  runZip(args: string[], cwd: string) {
+    return new Promise<void>((resolve, reject) => {
+      const child = spawn('zip', args, {
+        cwd,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        shell: false,
+      });
+      const stderrChunks: Buffer[] = [];
+      child.stderr.on('data', (chunk) => stderrChunks.push(chunk));
+      child.on('error', reject);
+      child.on('close', (code) => {
+        if (code === 0) return resolve();
+        const stderr = Buffer.concat(stderrChunks).toString('utf8');
+        reject(
+          new Errors.MoleculerError(
+            `zip exited with code ${code}: ${stderr || '<no stderr>'}`,
+            500,
+            'ZIP_FAILED',
+          ),
+        );
+      });
+    });
+  }
+}


### PR DESCRIPTION
## Summary

Adds a `POST /gdb` action to `biip-tools` (the shared internal services API at `internalapi.biip.lt/tools`), used to convert a GeoJSON FeatureCollection into a zipped ESRI File Geodatabase (`.gdb` directory packed as a ZIP). Mirrors the existing `/pdf`, `/screenshot`, `/download` services.

Driven by biip-uetk-api: when a user requests an extract in "Erdviniai duomenys (Geodatabase)" format on `/duomenu-gavimas`, the API assembles the per-request GeoJSON from the selected objects, POSTs it here, and uploads the returned ZIP to MinIO as the request's `generatedFile`.

## Changes

| File | Change |
|---|---|
| `services/gdb.service.ts` | New `gdb` service with `create` action exposed as `POST /gdb` |
| `Dockerfile` | `apk add gdal-tools zip` on the node:20-alpine base |
| `services/api.service.ts` | `bodyParsers.json/urlencoded.limit` 1MB → 25MB to accommodate GeoJSON payloads |

## Endpoint contract

```
POST /tools/gdb
Content-Type: application/json

{
  "geojson": { "type": "FeatureCollection", "features": [ ... ] },
  "srid":    3346,           // optional, default 3346 (LKS-94)
  "name":    "israsas-213"   // optional, default "extract"
                             // pattern: ^[A-Za-z0-9._-]+$
}

→ 200 application/zip
Content-Disposition: attachment; filename="<name>.zip"
```

The ZIP contains `<name>.gdb/...` (the conventional layout ArcGIS / QGIS expect).

## Implementation notes

- `ogr2ogr -f OpenFileGDB -a_srs EPSG:<srid> ...` does the conversion. `OpenFileGDB` is the open-source writer baked into Alpine's `gdal-tools` package.
- `zip -rq` packs the `.gdb` directory with `cwd: workDir` so paths are relative.
- Each request runs in its own `mkdtemp` workDir, cleaned up on stream close / error / upstream exception.
- Both `spawn` call sites pin the binary (`ogr2ogr`, `zip`) as a string literal with `shell: false`. The user-supplied `name` is validated against `^[A-Za-z0-9._-]+$` before it ever reaches the filesystem.
- Empty / non-FeatureCollection bodies are rejected with `INVALID_GEOJSON` / `EMPTY_FEATURES` 400s.

## Test plan

- [x] `yarn build` (tsc) clean
- [ ] After deploy: `curl -X POST internalapi.biip.lt/tools/gdb -d '{ "geojson": { "type":"FeatureCollection","features":[...] } }' -o out.zip` returns a valid ZIP whose `israsas-extract.gdb/` opens in QGIS
- [ ] Companion PR in biip-uetk-api wires `tools.makeGdb` to this endpoint
- [ ] Negative cases: empty features array → 400 EMPTY\\_FEATURES; non-FeatureCollection → 400 INVALID\\_GEOJSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)