### PR TITLE
fix: disable @sentry/node Undici integration to stop tools crash on every fetch

### DIFF
--- a/services/sentry.service.ts
+++ b/services/sentry.service.ts
@@ -19,8 +19,16 @@ import { Integrations } from '@sentry/node';
         environment: process.env.ENVIRONMENT,
         release: process.env.VERSION,
         tracesSampleRate: 1,
-        integrations: [
-          // enable HTTP calls tracing
+        // Disable the bundled Undici integration: @sentry/node 7.61.0's
+        // `setHeadersOnRequest` calls `request.headers.split()`, which
+        // crashes on newer Node 20 / undici where `request.headers` is an
+        // Array rather than a string. Every fetch() from this process
+        // (e.g. /tools/pdf → chrome) was triggering the crash, taking the
+        // whole tools container down on every PDF request. We keep the
+        // other default integrations (InboundFilters, FunctionToString,
+        // ConsoleBreadcrumbs, etc) plus our explicit Http/Postgres.
+        integrations: (defaultIntegrations: any[]) => [
+          ...defaultIntegrations.filter((i) => i.name !== 'Undici'),
           new Integrations.Http({ tracing: true }),
           new Integrations.Postgres(),
         ],


### PR DESCRIPTION
## Summary

biip-tools container was crashing on every POST /tools/pdf (and every other fetch the process made) with:

```
TypeError: request.headers.split is not a function
    at setHeadersOnRequest (@sentry/node/cjs/integrations/undici/index.js:248:39)
```

`@sentry/node` 7.61.0's bundled Undici integration calls `request.headers.split()`, but newer Node 20 / undici stores headers as an Array, not a string. The unhandled rejection terminates the Node process → yarn exits code 1 → container restarts.

Visible symptom: chrome completes the render but the response socket dies mid-stream, so every consumer (biip-uetk-api, biip-rusys-api) sees `MoleculerError: fetch failed` with cause `SocketError: other side closed`. **All tools-consumer flows on dev were broken.**

## Fix

Filter the buggy Undici integration out of `Sentry.init`'s integrations list. Keep all other default integrations plus the explicit Http + Postgres ones.

## Diagnostic evidence

From `diagnose-uetk-extract-pipeline`:
- chrome /pdf inbound: success @ 2s
- tools `POST /tools/pdf`: TypeError → restart loop
- uetk-api: `<= 500 GET /uetk/requests/223/pdf` with `MoleculerError: fetch failed`

## Test plan

- [x] `yarn build` clean
- [ ] After deploy: `/uetk/requests/:id/pdf` returns a real PDF (not 500)
- [ ] Extract approval flow (BullMQ) completes and writes `generatedFile` 

🤖 Generated with [Claude Code](https://claude.com/claude-code)