### PR TITLE
gdb: allow LT diacritics + digits in layer names

### DIFF
--- a/services/gdb.service.ts
+++ b/services/gdb.service.ts
@@ -45,9 +45,18 @@ export default class GdbService extends moleculer.Service {
           props: {
             name: {
               type: 'string',
-              // Layer-name rules match what ogr2ogr / OpenFileGDB accept and
-              // what the call site needs to splat into -nln safely.
-              pattern: '^[A-Za-z_][A-Za-z0-9_]{0,30}$',
+              // Layer-name rules — what ogr2ogr / OpenFileGDB accept and
+              // what the call site can splat into -nln safely. Allow
+              // ASCII letters + LT diacritics (ąčęėįšųūž) + digits +
+              // underscore. Disallow whitespace, shell metacharacters,
+              // and path separators — ogr2ogr would launder spaces to
+              // underscores anyway, and the shell:false spawn would
+              // not interpret quotes, but rejecting them upfront keeps
+              // the contract predictable. fastest-validator's `pattern`
+              // runs without the `u` flag, so we can't use \p{L};
+              // diacritics are spelled out instead.
+              pattern:
+                '^[A-Za-zĄČĘĖĮŠŲŪŽąčęėįšųūž_][A-Za-z0-9ĄČĘĖĮŠŲŪŽąčęėįšųūž_]{0,63}$',
             },
             geojson: 'object',
           },


### PR DESCRIPTION
Previous pattern `^[A-Za-z_][A-Za-z0-9_]{0,30}$` rejected layer names with language-specific letters. Widen to ASCII + LT diacritics (`ąčęėįšųūž`) + digits + underscore so callers can submit native-language layer names instead of transliterating. Length cap bumped 30 → 63 for compound names.

Whitespace, shell metacharacters, and path separators stay rejected — `ogr2ogr` OpenFileGDB driver launders spaces to underscores on its own, and the `shell:false` spawn does not interpret quotes, but rejecting them at the API keeps the contract predictable for callers.

`fastest-validator`'s `pattern` runs without the `u` flag, so `\\p{L}` won't work — diacritics are spelled out instead.

## Test plan

- [x] `yarn build` clean
- [ ] After deploy: `POST /gdb { layers: [{ name: 'Ežerai_ir_tvenkiniai', geojson: ... }] }` succeeds; resulting `.gdb` has the layer named verbatim
- [ ] Layer name with space → HTTP 400 (consistent with current behaviour)
- [ ] Existing callers using ASCII-only names keep working unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)